### PR TITLE
build: switch compile to api

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -37,16 +37,16 @@ dependencies {
     // contains util classes to support various android versions, and clean up code
     // comes with the awesome "Holder"-Pattern
     // https://github.com/mikepenz/Materialize
-    compile 'com.mikepenz:materialize:1.1.2@aar'
+    api 'com.mikepenz:materialize:1.1.2@aar'
 
     // used to provide out of the box icon font support. simplifies development,
     // and provides scalable icons. the core is very very light
     // https://github.com/mikepenz/Android-Iconics
-    compile 'com.mikepenz:iconics-core:2.9.5@aar'
+    api 'com.mikepenz:iconics-core:2.9.5@aar'
 
     // used to fill the RecyclerView with the DrawerItems
     // and provides single and multi selection, expandable items
     // https://github.com/mikepenz/FastAdapter
-    compile 'com.mikepenz:fastadapter:3.0.1@aar'
-    compile 'com.mikepenz:fastadapter-extensions-expandable:3.0.0@aar'
+    api 'com.mikepenz:fastadapter:3.0.1@aar'
+    api 'com.mikepenz:fastadapter-extensions-expandable:3.0.0@aar'
 }


### PR DESCRIPTION
Switch deprecated ```compile``` to the new ```api``` keyword